### PR TITLE
munch: overlay: Configure display cutout

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -460,11 +460,11 @@
          @see https://www.w3.org/TR/SVG/paths.html#PathData
          -->
     <string translatable="false" name="config_mainBuiltInDisplayCutout">
-        M 519,52
-        a 20,20 0 1 0 42,0
-        a 20,20 0 1 0 -42,0
+        M -23,52
+        M 23,52
+        A 23,23 0 1,0 -23,52
+        A 23,23 0 1,0 23,52
         Z
-        @left
     </string>
 
     <!-- Like config_mainBuiltInDisplayCutout, but this path is used to report the
@@ -474,12 +474,13 @@
          config_mainBuiltInDisplayCutout
          -->
     <string translatable="false" name="config_mainBuiltInDisplayCutoutRectApproximation">
-        M 493.5,0
-        h 95
-        v 95
-        h -95
+        M 0,0
+        H -23
+        V 75
+        H 23
+        V 0
+        H 0
         Z
-        @left
     </string>
 
     <!-- Whether the display cutout region of the main built-in display should be forced to

--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -27,7 +27,7 @@
     <!-- Height of the status bar.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
          -->
-    <dimen name="status_bar_height_default">28dp</dimen>
+    <dimen name="status_bar_height_default">25dp</dimen>
 
     <!-- Height of the status bar in portrait.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.


### PR DESCRIPTION
A circle cutout is drawn based on approximation that's taken from stock MIUI, but slightly edited to leave as minimum space below the camera cutout without leaving any visible jagged lines surounding the camera.